### PR TITLE
Make directSubTransX optional in the creation of the extension

### DIFF
--- a/shortcircuits-extensions/src/main/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitAdderImpl.java
+++ b/shortcircuits-extensions/src/main/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitAdderImpl.java
@@ -18,7 +18,7 @@ public class GeneratorShortCircuitAdderImpl extends AbstractExtensionAdder<Gener
         implements GeneratorShortCircuitAdder {
 
     double directTransX = 0;
-    double directSubtransX = 0;
+    double directSubtransX = Double.NaN;
     double stepUpTransformerX = Double.NaN;
 
     protected GeneratorShortCircuitAdderImpl(Generator extendable) {
@@ -27,7 +27,7 @@ public class GeneratorShortCircuitAdderImpl extends AbstractExtensionAdder<Gener
 
     @Override
     protected GeneratorShortCircuit createExtension(Generator extendable) {
-        return new GeneratorShortCircuitImpl(extendable, directTransX, directSubtransX, stepUpTransformerX);
+        return new GeneratorShortCircuitImpl(extendable, directSubtransX, directTransX, stepUpTransformerX);
     }
 
     @Override
@@ -50,7 +50,7 @@ public class GeneratorShortCircuitAdderImpl extends AbstractExtensionAdder<Gener
 
     @Override
     public Generator add() {
-        if (Double.isNaN(directSubtransX) || Double.isNaN(directTransX)) {
+        if (Double.isNaN(directTransX)) {
             throw new PowsyblException("Undefined directSubtransX or directTransX");
         }
         return super.add();

--- a/shortcircuits-extensions/src/main/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitAdderImpl.java
+++ b/shortcircuits-extensions/src/main/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitAdderImpl.java
@@ -51,7 +51,7 @@ public class GeneratorShortCircuitAdderImpl extends AbstractExtensionAdder<Gener
     @Override
     public Generator add() {
         if (Double.isNaN(directTransX)) {
-            throw new PowsyblException("Undefined directSubtransX or directTransX");
+            throw new PowsyblException("Undefined directTransX");
         }
         return super.add();
     }

--- a/shortcircuits-extensions/src/main/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitImpl.java
+++ b/shortcircuits-extensions/src/main/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitImpl.java
@@ -36,9 +36,6 @@ public class GeneratorShortCircuitImpl extends AbstractExtension<Generator> impl
 
     @Override
     public GeneratorShortCircuit setDirectSubtransX(double directSubtransX) {
-        if (Double.isNaN(directSubtransX)) {
-            throw new PowsyblException("Undefined directSubtranX");
-        }
         this.directSubtransX = directSubtransX;
         return this;
     }

--- a/shortcircuits-extensions/src/test/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitTest.java
+++ b/shortcircuits-extensions/src/test/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitTest.java
@@ -80,13 +80,7 @@ public class GeneratorShortCircuitTest {
         Network network = EurostagTutorialExample1Factory.create();
         Generator gen = network.getGenerator("GEN");
         assertNotNull(gen);
-        try {
-            gen.newExtension(GeneratorShortCircuitAdder.class)
-                    .withDirectTransX(Double.NaN)
-                    .add();
-            fail("Should throw exception when DirectTransX is NaN as it is mandatory");
-        } catch (PowsyblException e) {
-            assert e.getMessage().contains("Undefined directTransX");
-        }
+        PowsyblException e = assertThrows(PowsyblException.class, () -> gen.newExtension(GeneratorShortCircuitAdder.class).withDirectTransX(Double.NaN).add());
+        assertEquals(e.getMessage(), "Undefined directTransX");
     }
 }

--- a/shortcircuits-extensions/src/test/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitTest.java
+++ b/shortcircuits-extensions/src/test/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitTest.java
@@ -6,13 +6,13 @@
  */
 package com.powsybl.shortcircuits.extensions;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 /**
  * @author Coline Piloquet <coline.piloquet@rte-france.com>
@@ -73,5 +73,20 @@ public class GeneratorShortCircuitTest {
         assertEquals(Double.NaN, generatorShortCircuit.getStepUpTransformerX(), 0);
         generatorShortCircuit.setDirectTransX(10);
         assertEquals(10, generatorShortCircuit.getDirectTransX(), 0);
+    }
+
+    @Test
+    public void testWithoutTransX() {
+        Network network = EurostagTutorialExample1Factory.create();
+        Generator gen = network.getGenerator("GEN");
+        assertNotNull(gen);
+        try {
+            gen.newExtension(GeneratorShortCircuitAdder.class)
+                    .withDirectTransX(Double.NaN)
+                    .add();
+            fail("Should throw exception when DirectTransX is NaN as it is mandatory");
+        } catch (PowsyblException e) {
+            assert(e.getMessage().contains("Undefined directTransX"));
+        }
     }
 }

--- a/shortcircuits-extensions/src/test/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitTest.java
+++ b/shortcircuits-extensions/src/test/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitTest.java
@@ -58,4 +58,20 @@ public class GeneratorShortCircuitTest {
         generatorShortCircuit.setStepUpTransformerX(10);
         assertEquals(10, generatorShortCircuit.getStepUpTransformerX(), 0);
     }
+
+    @Test
+    public void testWithoutSubTransX() {
+        Network network = EurostagTutorialExample1Factory.create();
+        Generator gen = network.getGenerator("GEN");
+        assertNotNull(gen);
+        gen.newExtension(GeneratorShortCircuitAdder.class)
+                .withDirectTransX(20)
+                .add();
+        GeneratorShortCircuit generatorShortCircuit = gen.getExtension(GeneratorShortCircuit.class);
+        assertEquals(20, generatorShortCircuit.getDirectTransX(), 0);
+        assertEquals(Double.NaN, generatorShortCircuit.getDirectSubtransX(), 0);
+        assertEquals(Double.NaN, generatorShortCircuit.getStepUpTransformerX(), 0);
+        generatorShortCircuit.setDirectTransX(10);
+        assertEquals(10, generatorShortCircuit.getDirectTransX(), 0);
+    }
 }

--- a/shortcircuits-extensions/src/test/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitTest.java
+++ b/shortcircuits-extensions/src/test/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitTest.java
@@ -86,7 +86,7 @@ public class GeneratorShortCircuitTest {
                     .add();
             fail("Should throw exception when DirectTransX is NaN as it is mandatory");
         } catch (PowsyblException e) {
-            assert(e.getMessage().contains("Undefined directTransX"));
+            assert e.getMessage().contains("Undefined directTransX");
         }
     }
 }

--- a/shortcircuits-extensions/src/test/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitTest.java
+++ b/shortcircuits-extensions/src/test/java/com/powsybl/shortcircuits/extensions/GeneratorShortCircuitTest.java
@@ -81,6 +81,6 @@ public class GeneratorShortCircuitTest {
         Generator gen = network.getGenerator("GEN");
         assertNotNull(gen);
         PowsyblException e = assertThrows(PowsyblException.class, () -> gen.newExtension(GeneratorShortCircuitAdder.class).withDirectTransX(Double.NaN).add());
-        assertEquals(e.getMessage(), "Undefined directTransX");
+        assertEquals("Undefined directTransX", e.getMessage());
     }
 }


### PR DESCRIPTION
Signed-off-by: Coline Piloquet <coline.piloquet@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Change the subtransient reactance to optional


**What is the current behavior?** *(You can also link to an open issue here)*
The subtransient reactance is mandatory
